### PR TITLE
fix(pulsar-client): cast string from Rust to C

### DIFF
--- a/pulsar-client/src/error.rs
+++ b/pulsar-client/src/error.rs
@@ -1,7 +1,8 @@
 use std::{
     borrow::Cow,
     ffi::{CStr, NulError},
-    fmt::{self, Write},
+    fmt,
+    fmt::Write,
     num::TryFromIntError,
     path::Path,
     str::Utf8Error,
@@ -18,6 +19,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum Error {
+    #[snafu(display("{source}"))]
+    Ffi { source: Box<FfiError> },
+
     #[snafu(display("duration {duration:?} is not valid {unit}: {source}"))]
     InvalidDuration { duration: Box<Duration>, unit: Cow<'static, str>, source: FfiError },
 
@@ -65,6 +69,11 @@ pub enum Error {
 
     #[snafu(display("acknowledge error: {source}"))]
     Acknowledge { source: ResultCode },
+}
+
+impl From<FfiError> for Error {
+    #[inline]
+    fn from(source: FfiError) -> Self { Self::Ffi { source: Box::new(source) } }
 }
 
 #[derive(Debug, Snafu)]

--- a/pulsar-client/src/producer/message.rs
+++ b/pulsar-client/src/producer/message.rs
@@ -18,7 +18,7 @@ pub struct Message {
     pub partition_key: Option<String>,
 
     /// key to decide partition for the message
-    pub ordering_key: Option<Vec<u8>>,
+    pub ordering_key: Option<String>,
 
     /// Override namespace's replication
     pub replicate_to: Vec<String>,

--- a/pulsar-client/src/producer/mod.rs
+++ b/pulsar-client/src/producer/mod.rs
@@ -51,7 +51,7 @@ impl Producer {
     {
         let (tx, rx) = oneshot::channel::<Result<MessageId, ResultCode>>();
 
-        let message = crate::message::Message::from(Message::serialize_message(message)?);
+        let message = crate::message::Message::try_from(Message::serialize_message(message)?)?;
         unsafe {
             pulsar_producer_send_async(
                 self.as_ptr(),


### PR DESCRIPTION
Fix segmentation fault, error message:
```
[May26 03:01] tokio-runtime-w[1475967]: segfault at 1 ip 00007f25d1de3319 sp 00007f25a1fdc628 error 4 in libc-2.31.so[7f25d1ca7000+15a000]
[  +0.000010] Code: 00 31 c0 c5 f8 77 c3 66 2e 0f 1f 84 00 00 00 00 00 89 f8 48 89 fa c5 f9 ef c0 25 ff 0f 00 00 3d e0 0f 00 00 0f 87 37 01 00 00 <c5> fd 74 0f c5 fd d7 c1 85 c0 74 5b f3 0f bc c0 c5 f8 77 c3 0f 1f
```

---
- fix(pulsar-client): cast string from Rust to C
- style: remove repeat trailing blank line
